### PR TITLE
Adjustments made after extensive use

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -184,11 +184,19 @@ type CancelTime struct {
 
 type Orders []*Order
 
+//Per TD TDAmeritrade documentation, CancelTime should be a struct...
+// cancelTime": {
+//     "date": "string",
+//     "shortFormat": false
+//   }
+
+//However, the actual response is simply a string: YYYY-MM-DD
+//This will only apply to orders that are a limit order where the expiry is set.
 type Order struct {
 	Session                  string                `json:"session"`
 	Duration                 string                `json:"duration"`
 	OrderType                string                `json:"orderType"`
-	CancelTime               *CancelTime           `json:"cancelTime,omitempty"`
+	CancelTime               string                `json:"cancelTime,omitempty"`
 	ComplexOrderStrategyType string                `json:"complexOrderStrategyType,omitempty"`
 	Quantity                 float64               `json:"quantity,omitempty"`
 	FilledQuantity           float64               `json:"filledQuantity,omitempty"`

--- a/accounts.go
+++ b/accounts.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"time"
+	"net/http"
+	"strings"
+
+	"github.com/google/go-querystring/query"
 )
 
 type Accounts []*Account
@@ -170,7 +173,7 @@ type OrderLegCollection struct {
 	Instrument     Instrument `json:"instrument"`
 	Instruction    string     `json:"instruction"`
 	PositionEffect string     `json:"positionEffect,omitempty"`
-	Quantity       int        `json:"quantity"`
+	Quantity       float64    `json:"quantity"`
 	QuantityType   string     `json:"quantityType,omitempty"`
 }
 
@@ -178,6 +181,8 @@ type CancelTime struct {
 	Date        string `json:"date,omitempty"`
 	ShortFormat bool   `json:"shortFormat,omitempty"`
 }
+
+type Orders []*Order
 
 type Order struct {
 	Session                  string                `json:"session"`
@@ -248,10 +253,11 @@ type AccountOptions struct {
 }
 
 type OrderParams struct {
-	MaxResults int
-	From       time.Time
-	To         time.Time
-	Status     string
+	AccountId  string `url:"accountId"`
+	MaxResults int    `url:"maxResults,omitempty"`
+	From       string `url:"fromEnteredTime,omitempty"`
+	To         string `url:"toEnteredTime,omitempty"`
+	Status     string `url:"status,omitempty"`
 }
 
 func (i *Instrument) UnmarshalJSON(bs []byte) (err error) {
@@ -431,13 +437,28 @@ func (s *AccountsService) GetOrderByPath(ctx context.Context, accountID string, 
 	return s.client.Do(ctx, req, nil)
 }
 
-func (s *AccountsService) GetOrderByQuery(ctx context.Context, accountID string, orderParams *OrderParams) (*Response, error) {
-	u := fmt.Sprintf("accounts/%s/orders", accountID)
+func (s *AccountsService) GetOrdersByQuery(ctx context.Context, orderParams *OrderParams) (*Orders, *Response, error) {
+	u := fmt.Sprintf("orders")
+	if orderParams != nil {
+		q, err := query.Values(orderParams)
+		if err != nil {
+			return nil, nil, err
+		}
+		u = fmt.Sprintf("%s?%s", u, q.Encode())
+	}
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return s.client.Do(ctx, req, nil)
+
+	ords := new(Orders)
+	resp, err := s.client.Do(ctx, req, ords)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return ords, resp, nil
+
 }
 
 func (s *AccountsService) CreateSavedOrder(ctx context.Context, accountID string, order *Order) (*Response, error) {
@@ -484,4 +505,31 @@ func (s *AccountsService) ReplaceSavedOrder(ctx context.Context, accountID, save
 	}
 	req.Header.Set("Content-Type", "application/json")
 	return s.client.Do(ctx, req, nil)
+}
+
+//Utility for printing out requests for debugging.
+func PrintRequest(r *http.Request) string {
+	// Create return string
+	var request []string
+	// Add the request string
+	url := fmt.Sprintf("%v %v %v", r.Method, r.URL, r.Proto)
+	request = append(request, url)
+	// Add the host
+	request = append(request, fmt.Sprintf("Host: %v", r.Host))
+	// Loop through headers
+	for name, headers := range r.Header {
+		name = strings.ToLower(name)
+		for _, h := range headers {
+			request = append(request, fmt.Sprintf("%v: %v", name, h))
+		}
+	}
+
+	// If this is a POST, add post data
+	if r.Method == "POST" {
+		r.ParseForm()
+		request = append(request, "\n")
+		request = append(request, r.Form.Encode())
+	}
+	// Return the request as a string
+	return strings.Join(request, "\n")
 }

--- a/auth.go
+++ b/auth.go
@@ -104,7 +104,8 @@ func (a *Authenticator) FinishOAuth2Flow(ctx context.Context, w http.ResponseWri
 	if state[0] != expectedState {
 		return nil, fmt.Errorf("invalid state. expected: '%v', got '%v'", expectedState, state[0])
 	}
-	token, err := a.OAuth2.Exchange(ctx, code[0])
+
+	token, err := a.OAuth2.Exchange(ctx, code[0], oauth2.AccessTypeOffline)
 	if err != nil {
 		return nil, err
 	}

--- a/priceHistory.go
+++ b/priceHistory.go
@@ -28,7 +28,7 @@ type PriceHistoryService struct {
 
 // PriceHistoryOptions is parsed and translated to query options in the https request
 //cannot use time.Time in StartDate and EndDate. Date must be Epoch time.
-//Use new function ConvertToEpoch() which returns and int64.
+//Use new function ConvertToEpoch() which returns an int64.
 //This is per the documentation from TD AMERITRADE.
 //also, omitempty must be set because if you set a start and end date, you cannot send the "period" value or it will error.
 type PriceHistoryOptions struct {
@@ -73,8 +73,6 @@ func (s *PriceHistoryService) PriceHistory(ctx context.Context, symbol string, o
 	if err != nil {
 		return nil, nil, err
 	}
-
-	fmt.Println(PrintRequest(req))
 
 	priceHistory := new(PriceHistory)
 	resp, err := s.client.Do(ctx, req, priceHistory)


### PR DESCRIPTION
I've been using this repo for making a Trading Journal. In the process, I ran into a few bugs and things that didn't work during implementation. 

First, I set the AccessType to OffLine. The reason for this was that, I wanted to get the refresh token so my app would automatically refresh every 30 minutes. This possibly could've been made an option but the other parts of the repo (as well as the examples) show that the refresh token is being saved. Without he AccessTypeOffLine, you don't get a refresh token. 

When running the GetOrderByQuery, the params were not implemented. So when passing in params, they weren't used. 

PriceHistory time must be passed to TD Ameritrade in Epoch time. Therefore, I changed the type from time.Time to an int64. 

There is also a PrintRequest() function I added but I used that for the debugging requests to see why TD Ameritrade was rejecting some of my requests. It's useful for comparing directly to the API but can be left out as it's not actually needed for the package itself. 